### PR TITLE
cohttp 2.5.8: fix archive url

### DIFF
--- a/packages/cohttp-async/cohttp-async.2.5.8/opam
+++ b/packages/cohttp-async/cohttp-async.2.5.8/opam
@@ -51,7 +51,7 @@ build: [
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 url {
   src:
-    "https://github.com/mirage/ocaml-cohttp/releases/download/2.5.8/cohttp-2.5.8.tbz"
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v2.5.8/cohttp-2.5.8.tbz"
   checksum: [
     "sha256=2722477d1f5bb09e841debc125c30ff44f1b20cf8894b68cb48f2b6de092d25a"
     "sha512=ce934a24c0e1eaf5dc674927b45277d461a13757d4c165a4a11811f9eb7b11b78b4560792ca430734d4e3a5b8791eee887d4eab2a0e9e30aa4a5864e833dd768"

--- a/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.2.5.8/opam
+++ b/packages/cohttp-lwt-jsoo/cohttp-lwt-jsoo.2.5.8/opam
@@ -39,7 +39,7 @@ build: [
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 url {
   src:
-    "https://github.com/mirage/ocaml-cohttp/releases/download/2.5.8/cohttp-2.5.8.tbz"
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v2.5.8/cohttp-2.5.8.tbz"
   checksum: [
     "sha256=2722477d1f5bb09e841debc125c30ff44f1b20cf8894b68cb48f2b6de092d25a"
     "sha512=ce934a24c0e1eaf5dc674927b45277d461a13757d4c165a4a11811f9eb7b11b78b4560792ca430734d4e3a5b8791eee887d4eab2a0e9e30aa4a5864e833dd768"

--- a/packages/cohttp-lwt-unix/cohttp-lwt-unix.2.5.8/opam
+++ b/packages/cohttp-lwt-unix/cohttp-lwt-unix.2.5.8/opam
@@ -45,7 +45,7 @@ build: [
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 url {
   src:
-    "https://github.com/mirage/ocaml-cohttp/releases/download/2.5.8/cohttp-2.5.8.tbz"
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v2.5.8/cohttp-2.5.8.tbz"
   checksum: [
     "sha256=2722477d1f5bb09e841debc125c30ff44f1b20cf8894b68cb48f2b6de092d25a"
     "sha512=ce934a24c0e1eaf5dc674927b45277d461a13757d4c165a4a11811f9eb7b11b78b4560792ca430734d4e3a5b8791eee887d4eab2a0e9e30aa4a5864e833dd768"

--- a/packages/cohttp-lwt/cohttp-lwt.2.5.8/opam
+++ b/packages/cohttp-lwt/cohttp-lwt.2.5.8/opam
@@ -41,7 +41,7 @@ build: [
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 url {
   src:
-    "https://github.com/mirage/ocaml-cohttp/releases/download/2.5.8/cohttp-2.5.8.tbz"
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v2.5.8/cohttp-2.5.8.tbz"
   checksum: [
     "sha256=2722477d1f5bb09e841debc125c30ff44f1b20cf8894b68cb48f2b6de092d25a"
     "sha512=ce934a24c0e1eaf5dc674927b45277d461a13757d4c165a4a11811f9eb7b11b78b4560792ca430734d4e3a5b8791eee887d4eab2a0e9e30aa4a5864e833dd768"

--- a/packages/cohttp-mirage/cohttp-mirage.2.5.8/opam
+++ b/packages/cohttp-mirage/cohttp-mirage.2.5.8/opam
@@ -40,7 +40,7 @@ build: [
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 url {
   src:
-    "https://github.com/mirage/ocaml-cohttp/releases/download/2.5.8/cohttp-2.5.8.tbz"
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v2.5.8/cohttp-2.5.8.tbz"
   checksum: [
     "sha256=2722477d1f5bb09e841debc125c30ff44f1b20cf8894b68cb48f2b6de092d25a"
     "sha512=ce934a24c0e1eaf5dc674927b45277d461a13757d4c165a4a11811f9eb7b11b78b4560792ca430734d4e3a5b8791eee887d4eab2a0e9e30aa4a5864e833dd768"

--- a/packages/cohttp-top/cohttp-top.2.5.8/opam
+++ b/packages/cohttp-top/cohttp-top.2.5.8/opam
@@ -33,7 +33,7 @@ build: [
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 url {
   src:
-    "https://github.com/mirage/ocaml-cohttp/releases/download/2.5.8/cohttp-2.5.8.tbz"
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v2.5.8/cohttp-2.5.8.tbz"
   checksum: [
     "sha256=2722477d1f5bb09e841debc125c30ff44f1b20cf8894b68cb48f2b6de092d25a"
     "sha512=ce934a24c0e1eaf5dc674927b45277d461a13757d4c165a4a11811f9eb7b11b78b4560792ca430734d4e3a5b8791eee887d4eab2a0e9e30aa4a5864e833dd768"

--- a/packages/cohttp/cohttp.2.5.8/opam
+++ b/packages/cohttp/cohttp.2.5.8/opam
@@ -56,7 +56,7 @@ build: [
 dev-repo: "git+https://github.com/mirage/ocaml-cohttp.git"
 url {
   src:
-    "https://github.com/mirage/ocaml-cohttp/releases/download/2.5.8/cohttp-2.5.8.tbz"
+    "https://github.com/mirage/ocaml-cohttp/releases/download/v2.5.8/cohttp-2.5.8.tbz"
   checksum: [
     "sha256=2722477d1f5bb09e841debc125c30ff44f1b20cf8894b68cb48f2b6de092d25a"
     "sha512=ce934a24c0e1eaf5dc674927b45277d461a13757d4c165a4a11811f9eb7b11b78b4560792ca430734d4e3a5b8791eee887d4eab2a0e9e30aa4a5864e833dd768"


### PR DESCRIPTION
Dune release stripped the v from the url. Seen on https://github.com/ocaml/opam-repository/pull/23891